### PR TITLE
RFC 3339 compliant

### DIFF
--- a/lib/XML/Atom/SimpleFeed.pm
+++ b/lib/XML/Atom/SimpleFeed.pm
@@ -111,7 +111,7 @@ sub date_construct {
 	}
 	elsif ( ref $dt and eval { $dt->can( 'strftime' ) } ) {
 		$dt = $dt->strftime( W3C_DATETIME . '%z' );
-		$dt =~ s!(\d\d)\z!$1:!;
+		substr ($dt, -2, 0) = ':';				# rfc 3339 compliant
 	}
 
 	xml_tag $name, xml_escape $dt;


### PR DESCRIPTION
Hi

With this small change the output will be RFC 3339 compliant. Otherwise the numeric timezone offset will be published as "[+|-]\d\d\d\d". But the correct output has to look like "[+|-]\d\d:\d\d"

Greetings
